### PR TITLE
fix: fix check_ssl endpoint path operation method

### DIFF
--- a/app/api/v1/routes/ssl.py
+++ b/app/api/v1/routes/ssl.py
@@ -30,7 +30,7 @@ def check_website_ssl(
     ssl_status = ssl_checker.check_ssl_status(website.url, website.id, db)
     return ssl_status
 
-@router.post("/check-ssl", response_model=SSLStatusResponse)
+@router.get("/check-ssl", response_model=SSLStatusResponse)
 def check_ssl(
     url: str,
     ssl_checker: SSLCheckerService = Depends(SSLCheckerService)


### PR DESCRIPTION
### What does this PR do?
- Modifies `check_ssl` path operation method from `POST` to `GET`.

### Why this change?
- `check_ssl`  endpoint `/check-ssl` does not modify/update the server state, it just runs an ssl check for an arbitrary url.
