### PR TITLE
feat: add filtering to ssl logs endpoint

### DIFF
--- a/app/utils/ssl.py
+++ b/app/utils/ssl.py
@@ -1,4 +1,4 @@
-from sqlalchemy.exc import SQLAlchemyError
+from fastapi import Query
 from sqlmodel import Session, select
 from app.api.v1.models import SSLLog
 
@@ -10,3 +10,11 @@ def get_ssl_logs_by_website_id(db: Session, website_id: str):
     ssl_logs = db.exec(statement).all()
 
     return ssl_logs
+
+def valid_logs_query(query: Query, is_valid: bool) -> Query:
+    """Apply validity filter to  query if specified"""  
+    return query.where(SSLLog.is_valid == is_valid)
+
+def all_logs_query(db: Session, website_id: str) -> Query:
+    """Create a query to retrieve SSL logs for a specific website"""
+    return select(SSLLog).where(SSLLog.website_id == website_id)

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,6 +17,7 @@ services:
       
     volumes:
       - ./alembic/versions:/app/alembic/versions  # Link Alembic migrations
+      - .:/app
     
 
   db:

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -66,3 +66,17 @@ def test_get_ssl_logs_not_found(client):
     response = client.get("/websites/999/ssl-logs")
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json() == {"detail": "SSL logs not found for this website"}    
+    
+def test_get_valid_logs_only(client, test_logs):
+    # Test filtering only valid logs
+    response = client.get("/websites/1/ssl-logs?is_valid=true")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert len(data) == 2
+
+def test_get_invalid_logs_only(client, test_logs):
+    # Test filtering only valid logs
+    response = client.get("/websites/1/ssl-logs?is_valid=false")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert len(data) == 1


### PR DESCRIPTION
### What does this PR do?
- Adds `is_valid` filter to `get_ssl_logs` endpoint.
- Adds corresponding tests.

### Related issue?
- Resolves #52 