### PR TITLE
refactor: modify ssl uptime validation

### DIFF
--- a/alembic/versions/4483627f1ce1_002_add_url_scheme_check_constraint.py
+++ b/alembic/versions/4483627f1ce1_002_add_url_scheme_check_constraint.py
@@ -1,0 +1,43 @@
+"""002_add_url_scheme_check_constraint
+
+Revision ID: 4483627f1ce1
+Revises: 211f0fd1a2f2
+Create Date: 2025-04-07 19:40:58.574978
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4483627f1ce1"
+down_revision: Union[str, None] = "211f0fd1a2f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Data migration: Prepend 'https://' to already existing URLs without a scheme
+    op.execute(
+        """
+        UPDATE website
+        SET url = 'https://' || url
+        WHERE url NOT LIKE 'http://%' AND url NOT LIKE 'https://%'
+    """
+    )
+
+    # Schema migration: Add CHECK constraint to enforce schemes
+    op.execute(
+        """
+        ALTER TABLE website
+        ADD CONSTRAINT check_url_scheme
+        CHECK (url LIKE 'http://%' OR url LIKE 'https://%')
+    """
+    )
+
+
+def downgrade() -> None:
+    # Remove the CHECK constraint
+    op.execute("ALTER TABLE website DROP CONSTRAINT check_url_scheme")

--- a/app/api/v1/routes/ssl.py
+++ b/app/api/v1/routes/ssl.py
@@ -24,7 +24,17 @@ def check_website_ssl(website_id: str, db: Session = Depends(get_db)) -> Dict[st
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Website with id {website_id} not found",
         )
-    # TODO: check if ssl_check_enabled is True and website is active
+    # Check if ssl_check_enabled is True and website is active
+    if not website.ssl_check_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"SSL checks are disabled for website {website_id}",
+        )
+    if not website.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Website {website_id} is inactive",
+        )
     # Trigger SSL check asynchronously
     check_ssl_status_task.delay(website.url, website.id)
 

--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -1,7 +1,8 @@
 from urllib.parse import urlparse
 
 import validators
-from exceptions.ssl import InvalidURLException
+
+from app.exceptions.ssl import InvalidURLException
 
 
 def validate_url(url: str) -> str:

--- a/app/utils/generic.py
+++ b/app/utils/generic.py
@@ -1,0 +1,32 @@
+from urllib.parse import urlparse
+
+import validators
+from exceptions.ssl import InvalidURLException
+
+
+def validate_url(url: str) -> str:
+    """
+    Validate a URL and return its domain or full URL for HTTP requests.
+
+    Args:
+        url: The URL to validate (e.g., "https://example.com").
+
+    Returns:
+        str: The validated domain or URL (e.g., "example.com" or "https://example.com").
+
+    Raises:
+        InvalidURLException: If the URL is invalid or lacks a domain.
+    """
+    if not validators.url(url):
+        raise InvalidURLException("Invalid URL format")
+
+    parsed_url = urlparse(url)
+    domain = parsed_url.netloc or parsed_url.path
+
+    if not domain:
+        raise InvalidURLException("Invalid URL: No domain found")
+
+    if parsed_url.scheme not in ("http", "https"):
+        raise InvalidURLException("URL must use http or https scheme")
+
+    return domain


### PR DESCRIPTION
### What does this PR do?
- Add `is_active` and `ssl_check_enabled` checks to SSL check endpoint    
- Filter `periodic_ssl_check` to active websites only
- Refactor `check_website_uptime` with `validate_url` utility
- Introduce`validate_url` for reusable URL validation
- Update existing website urls to include `https://` scheme if missing
- Add `CHECK ` constraint to ensure all urls have `http://` or `https://`
