### PR TITLE
feat(api): define uptime cr endpoints

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,12 +1,14 @@
 from fastapi import FastAPI
 
 from .api.v1.routes.ssl import router as ssl_router
+from .api.v1.routes.website import router as website_router
 
 
 def create_app() -> FastAPI:
     app = FastAPI()
 
     app.include_router(ssl_router, tags=["ssl"])
+    app.include_router(website_router, tags=["websites"])
     return app
 
 

--- a/app/api/v1/models.py
+++ b/app/api/v1/models.py
@@ -64,6 +64,7 @@ class NotificationPreference(SQLModel, table=True):
 
 class UptimeLog(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
+    # TODO: add index to website_id and timestamp
     website_id: str = Field(..., foreign_key="website.id")
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     is_up: bool

--- a/app/api/v1/routes/website.py
+++ b/app/api/v1/routes/website.py
@@ -1,0 +1,53 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session
+
+from app.api.v1.schemas import UptimeLogResponse, WebsiteCreate, WebsiteRead
+from app.dependencies.db import get_db
+from app.utils.website import (
+    create_website,
+    get_uptime_logs,
+    get_website_by_id,
+    get_website_by_url,
+)
+
+router = APIRouter(prefix="/websites", tags=["websites"])
+
+
+@router.post("/", response_model=WebsiteRead, status_code=status.HTTP_201_CREATED)
+def create_website_endpoint(
+    website: WebsiteCreate, db: Session = Depends(get_db)
+) -> WebsiteRead:
+    """
+    Register a new website for uptime monitoring
+    """
+    # Check if the website already exists
+    existing_website = get_website_by_url(db, website.url)
+    if existing_website:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Website with URL {website.url} already exists",
+        )
+    new_website = create_website(db, website)
+    return new_website
+
+
+@router.get("/{website_id}/uptime-logs", response_model=List[UptimeLogResponse])
+def get_uptime_logs_endpoint(
+    website_id: str,
+    limit: int = 10,
+    offset: int = 0,
+    db: Session = Depends(get_db),
+) -> List[UptimeLogResponse]:
+    """
+    Retrieve uptime logs for a specific website with pagination
+    """
+    website = get_website_by_id(db, website_id)
+    if not website:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Website with id {website_id} not found",
+        )
+    logs = get_uptime_logs(db, website_id, limit, offset)
+    return logs

--- a/app/api/v1/schemas.py
+++ b/app/api/v1/schemas.py
@@ -100,3 +100,9 @@ class UptimeLogResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class PaginatedUptimeLogResponse(BaseModel):
+    data: List[UptimeLogResponse]
+    next_cursor: Optional[datetime] = None
+    has_next: bool = False  # More logs available?

--- a/app/utils/website.py
+++ b/app/utils/website.py
@@ -1,15 +1,38 @@
+from typing import List
+
 from sqlmodel import Session, select
 
-from app.api.v1.models import Website
+from app.api.v1.models import UptimeLog, Website
+from app.api.v1.schemas import WebsiteCreate
+
+
+def create_website(db: Session, website: WebsiteCreate) -> Website:
+    """Create a new website in the database"""
+    # Convert HttpUrl to str explicitly
+    website_data = website.model_dump()
+    website_data["url"] = str(website.url)  # HttpUrl -> str
+    website_in = Website(**website_data)
+    db.add(website_in)
+    db.commit()
+    db.refresh(website_in)
+    return website_in
 
 
 def get_website_by_id(db: Session, website_id: str):
     """
     Retrieve a website by its ID
     """
-    statement = select(Website).where(Website.id == website_id)
-    website = db.exec(statement).first()
+    website = db.get(Website, website_id)
+    return website
 
+
+def get_website_by_url(db: Session, url: str):
+    """
+    Retrieve a website by its ID
+    """
+    website_url = str(url)
+    statement = select(Website).where(Website.url == website_url)
+    website = db.exec(statement).first()
     return website
 
 
@@ -21,3 +44,17 @@ def get_all_websites(db: Session):
     websites = db.exec(statement).all()
 
     return websites
+
+
+def get_uptime_logs(
+    db: Session, website_id: str, limit: int = 10, offset: int = 0
+) -> List[UptimeLog]:
+    """Fetch uptime logs for a website with pagination."""
+    query = (
+        select(UptimeLog)
+        .where(UptimeLog.website_id == website_id)
+        .order_by(UptimeLog.timestamp.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    return db.exec(query).all()


### PR DESCRIPTION
### What does this PR do?
 - Adds `POST /websites` to register websites
- Adds `GET /websites/{website_id}/uptime-logs` with pagination
- Creates CRUD functions for website and uptime log management
- Adds `PaginatedUptimeLogResponse` with next_cursor and has_next
- Update `get_uptime_logs` to return paginated metadata

### Related issue?
- Resolves #63 