### PR TITLE
feat: add retrieve websites endpoint

### DIFF
--- a/app/api/v1/routes/website.py
+++ b/app/api/v1/routes/website.py
@@ -133,13 +133,12 @@ def delete_website_endpoint(
 @router.get("/search", response_model=WebsiteSearchResponse)
 def search_websites_endpoint(
     q: str = Query(..., description="Search term for url or name"),
-    # TODO: type hint for after should be UUID, also change the name to cursor
-    after: Optional[str] = Query(None, description="Fetch websites after this id"),
+    cursor: Optional[UUID] = Query(None),
     limit: int = Query(10, ge=1, le=100),
     db: Session = Depends(get_db),
 ) -> WebsiteSearchResponse:
     """
     Search websites by url or name with cursor pagination.
     """
-    result = search_websites(db, query=q, after=after, limit=limit)
+    result = search_websites(db, query=q, cursor=cursor, limit=limit)
     return WebsiteSearchResponse(**result)

--- a/app/api/v1/routes/website.py
+++ b/app/api/v1/routes/website.py
@@ -60,7 +60,7 @@ def get_websites_endpoint(
 
 
 @router.get("/{website_id}", response_model=WebsiteRead)
-def get_individual_website_endpoint(
+def get_single_website_endpoint(
     website_id: UUID,
     db: Session = Depends(get_db),
 ) -> WebsiteRead:

--- a/app/api/v1/schemas.py
+++ b/app/api/v1/schemas.py
@@ -109,11 +109,11 @@ class SSLLogResponse(BaseModel):
         from_attributes = True
 
 
-# TODO: add has_next field
 # New wrapper model for paginated response
 class PaginatedSSLLogResponse(BaseModel):
     data: List[SSLLogResponse]
     next_cursor: Optional[int] = None
+    has_next: bool = False
 
 
 class UptimeLogResponse(BaseModel):

--- a/app/api/v1/schemas.py
+++ b/app/api/v1/schemas.py
@@ -59,6 +59,12 @@ class WebsiteRead(WebsiteBase):
         from_attributes = True
 
 
+class PaginatedWebsiteReadResponse(BaseModel):
+    data: List[WebsiteRead]
+    next_cursor: Optional[str] = None
+    has_next: bool = False  # More logs available?
+
+
 class WebsiteUpdate(BaseModel):
     url: Optional[HttpUrl] = None
     name: Optional[str] = None
@@ -103,6 +109,7 @@ class SSLLogResponse(BaseModel):
         from_attributes = True
 
 
+# TODO: add has_next field
 # New wrapper model for paginated response
 class PaginatedSSLLogResponse(BaseModel):
     data: List[SSLLogResponse]

--- a/app/utils/crud.py
+++ b/app/utils/crud.py
@@ -174,7 +174,7 @@ def delete_website(db: Session, website_id: UUID) -> bool:
 def search_websites(
     db: Session,
     query: str,
-    after: Optional[str] = None,
+    cursor: Optional[str] = None,
     limit: int = 10,
 ) -> dict:
     """Search websites by url or name with cursor pagination"""
@@ -190,8 +190,8 @@ def search_websites(
             )
         )
 
-    if after:
-        sql_query = sql_query.where(Website.id > after)
+    if cursor:
+        sql_query = sql_query.where(Website.id > cursor)
 
     sql_query = sql_query.order_by(Website.id.asc()).limit(limit + 1)
     websites = db.exec(sql_query).all()

--- a/app/utils/crud.py
+++ b/app/utils/crud.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import Dict, Optional
 from uuid import UUID
 
 from fastapi import HTTPException, status
@@ -30,6 +30,7 @@ def fetch_ssl_logs(
 
     ssl_logs = db.exec(query).all()
 
+    # TODO: return empty list instead of raising exception
     if not ssl_logs:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -80,14 +81,29 @@ def get_website_by_url(db: Session, url: str):
     return website
 
 
-def get_all_websites(db: Session):
+def get_all_websites(db: Session, cursor: Optional[UUID] = None, limit=10) -> Dict:
     """
-    Retrieve all websites from the database
+    Retrieve all websites from db with cursor-based pagination
     """
-    statement = select(Website)
-    websites = db.exec(statement).all()
+    query = select(Website)
+    if cursor:
+        query = query.where(Website.id > cursor)
+    query = query.order_by(Website.id.asc()).limit(limit + 1)
+    websites = db.exec(query).all()
 
-    return websites
+    if not websites:
+        return {"data": [], "next_cursor": None, "has_next": False}
+
+    # Check if there's a next page
+    has_next = len(websites) > limit
+    if has_next:
+        websites = websites[:limit]  # Trim to requested limit
+    next_cursor = websites[-1].id if has_next else None
+    return {
+        "data": websites,
+        "next_cursor": next_cursor,
+        "has_next": has_next,
+    }
 
 
 def fetch_uptime_logs(
@@ -107,6 +123,7 @@ def fetch_uptime_logs(
     query = query.order_by(UptimeLog.timestamp.asc()).limit(limit + 1)
     uptime_logs = db.exec(query).all()
 
+    # TODO: return empty list instead of raising exception
     if not uptime_logs:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/app/utils/crud.py
+++ b/app/utils/crud.py
@@ -81,7 +81,9 @@ def get_website_by_url(db: Session, url: str):
     return website
 
 
-def get_all_websites(db: Session, cursor: Optional[UUID] = None, limit=10) -> Dict:
+def get_all_websites(
+    db: Session, cursor: Optional[UUID] = None, limit: Optional[int] = 10
+) -> Dict:
     """
     Retrieve all websites from db with cursor-based pagination
     """
@@ -101,7 +103,9 @@ def get_all_websites(db: Session, cursor: Optional[UUID] = None, limit=10) -> Di
     next_cursor = websites[-1].id if has_next else None
     return {
         "data": websites,
-        "next_cursor": next_cursor,
+        "next_cursor": str(
+            next_cursor
+        ),  # cast uuid website id to str for json serialization
         "has_next": has_next,
     }
 

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -86,6 +86,23 @@ def test_get_all_websites(client, test_db: Session, user_with_notification_prefe
     assert len(data["data"]) == 1
 
 
+def test_get_single_website(
+    client, test_db: Session, user_with_notification_preference
+):
+    user, _ = user_with_notification_preference
+    website = Website(
+        id=uuid4(), name="Test Website", url="https://example.com/", user=user
+    )
+    test_db.add(website)
+    test_db.commit()
+    test_db.refresh(website)
+
+    response = client.get(f"/websites/{website.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == str(website.id)
+
+
 def test_update_website(client, test_db: Session, user_with_notification_preference):
     user, _ = user_with_notification_preference
     normalized_url = HttpUrl("https://example.com")


### PR DESCRIPTION
### What does this PR do?
- Adds `GET /websites/{website_id}` endpoint
- Adds `GET /websites` endpoint
- Adds corresponding tests for the endpoints
- Addresses todo items: updates `cursor` in `search_websites_endpoint`, adds `has_next` in `PaginatedSSLLogResponse`

### Related issue?
- Resolves #81 