### PR TITLE
test: add search websites tests

### DIFF
--- a/app/api/v1/routes/website.py
+++ b/app/api/v1/routes/website.py
@@ -59,6 +59,20 @@ def get_websites_endpoint(
     return PaginatedWebsiteReadResponse(**result)
 
 
+@router.get("/search", response_model=WebsiteSearchResponse)
+def search_websites_endpoint(
+    q: str = Query(..., description="Search term for url or name"),
+    cursor: Optional[UUID] = Query(None),
+    limit: int = Query(10, ge=1, le=100),
+    db: Session = Depends(get_db),
+) -> WebsiteSearchResponse:
+    """
+    Search websites by url or name with cursor pagination.
+    """
+    result = search_websites(db, query=q, cursor=cursor, limit=limit)
+    return WebsiteSearchResponse(**result)
+
+
 @router.get("/{website_id}", response_model=WebsiteRead)
 def get_single_website_endpoint(
     website_id: UUID,
@@ -128,17 +142,3 @@ def delete_website_endpoint(
             detail=f"Website with id {website_id} not found",
         )
     return None
-
-
-@router.get("/search", response_model=WebsiteSearchResponse)
-def search_websites_endpoint(
-    q: str = Query(..., description="Search term for url or name"),
-    cursor: Optional[UUID] = Query(None),
-    limit: int = Query(10, ge=1, le=100),
-    db: Session = Depends(get_db),
-) -> WebsiteSearchResponse:
-    """
-    Search websites by url or name with cursor pagination.
-    """
-    result = search_websites(db, query=q, cursor=cursor, limit=limit)
-    return WebsiteSearchResponse(**result)

--- a/app/utils/crud.py
+++ b/app/utils/crud.py
@@ -174,7 +174,7 @@ def delete_website(db: Session, website_id: UUID) -> bool:
 def search_websites(
     db: Session,
     query: str,
-    cursor: Optional[str] = None,
+    cursor: Optional[UUID] = None,
     limit: int = 10,
 ) -> dict:
     """Search websites by url or name with cursor pagination"""
@@ -197,10 +197,7 @@ def search_websites(
     websites = db.exec(sql_query).all()
 
     if not websites:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"No website found matching {query}",
-        )
+        return {"data": [], "next_cursor": None, "has_next": False}
 
     has_next = len(websites) > limit
     websites = websites[:limit]
@@ -208,6 +205,6 @@ def search_websites(
     next_cursor = websites[-1].id if has_next else None
     return {
         "data": websites,
-        "next_cursor": next_cursor,
+        "next_cursor": str(next_cursor),
         "has_next": has_next,
     }

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -220,3 +220,26 @@ def test_get_logs_for_non_existent_website(client):
     response = client.get(f"/websites/{non_existent_uuid}/uptime-logs")
     assert response.status_code == 404
     assert response.json()["detail"] == "Website not found"
+
+
+def test_search_website_success(
+    client, test_db: Session, user_with_notification_preference
+):
+    user, _ = user_with_notification_preference
+    website1 = Website(
+        id=uuid4(), name="Test Website 1", url="https://example.com/", user=user
+    )
+    website2 = Website(
+        id=uuid4(), name="Test Website 2", url="https://example.org/", user=user
+    )
+    test_db.add_all([website1, website2])
+    test_db.commit()
+
+    response = client.get("/websites/search?q=Test")
+    import pdb
+
+    pdb.set_trace()
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["data"]) == 2
+    assert data["has_next"] is False

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -264,4 +264,11 @@ def test_search_website_paginated(
     data = response.json()
     assert len(data["data"]) == 2
     assert data["has_next"] is True
-    assert data["next_cursor"] == str(website2.id)
+
+    # Test next page
+    response = client.get(
+        f"/websites/search?q=Test&cursor={data['next_cursor']}&limit=2"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["data"]) == 1


### PR DESCRIPTION
### What does this PR do?
- Reorders routes to prioritize static route `websites/search` over `websites/{website_id}`
- Returns empty list for no search results
- Adds paginated results `GET websites/search` endpoint
- Modifies paginated GET /search endpoint test

### Related issue?
- Resolves #76 